### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ let when = ['before the class','right on time','when I finished','during my lunc
 HTML, CSS3, Sass, Javascript, Webpack.
 
 ## Fundamentals
+
 This exercise covers the following fundamentals:
+
 1. Using external Javascript files in your project.
 2. How to work with Arrays.
 3. Generating random numbers.


### PR DESCRIPTION
Algunos parsers de markdown no interpretan una lista de elementos si el primer elemento de la lista no tiene una linea en blanco por encima.